### PR TITLE
Enable link checks in Ultralytics Actions

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -29,7 +29,7 @@ jobs:
           python: false # No Python files in this repository
           prettier: true # Format YAML, JSON, Markdown, CSS
           spelling: true # Check spelling with codespell
-          links: false # Check broken links with Lychee
+          links: true # Check broken links with Lychee
           summary: true # Generate AI-powered PR summaries
           openai_api_key: ${{ secrets.OPENAI_API_KEY }} # Powers PR summaries, labels and comments
           brave_api_key: ${{ secrets.BRAVE_API_KEY }} # Used for broken link resolution


### PR DESCRIPTION
Aligns `.github/workflows/format.yml` with the current Ultralytics repository standard by enabling the Lychee broken-link check (`links: true`). No other configuration changes.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Enabled Lychee broken-link checking in the repository’s standard formatting workflow to detect invalid links in pull requests.

### 📊 Key Changes
- Changed `links` from `false` to `true` in `.github/workflows/format.yml`.
- Kept all other Ultralytics Actions configuration unchanged.
- The workflow continues to run formatting, spelling, summary, and related checks as configured.

### 🎯 Purpose & Impact
- Pull requests now include automated broken-link checks through Lychee.
- No application or runtime behavior changes.