### PR TITLE
Remove dead YouTube link and enable link checks

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -29,7 +29,7 @@ jobs:
           python: false # No Python files in this repository
           prettier: true # Format YAML, JSON, Markdown, CSS
           spelling: true # Check spelling with codespell
-          links: false # Check broken links with Lychee
+          links: true # Check broken links with Lychee
           summary: true # Generate AI-powered PR summaries
           openai_api_key: ${{ secrets.OPENAI_API_KEY }} # Powers PR summaries, labels and comments
           brave_api_key: ${{ secrets.BRAVE_API_KEY }} # Used for broken link resolution

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Welcome to the [Ultralytics Kinect](https://github.com/ultralytics/kinect) repository! This project showcases advanced **3D scene reconstruction** algorithms utilizing data captured by the [Microsoft Kinect sensor](https://en.wikipedia.org/wiki/Kinect), a pioneering [depth-imaging](https://www.ultralytics.com/glossary/depth-estimation) device. Explore our implementation of cutting-edge techniques in [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) and see the results in action through example videos on the [Ultralytics YouTube channel](https://www.youtube.com/ultralytics).
 
-[![Kinect Video Preview](preview.jpg)](https://youtu.be/dqK5DkgTGyk "Click to Watch the 3D Reconstruction Demo!")
+![Kinect 3D reconstruction preview](preview.jpg)
 
 ## Prerequisites 🛠️
 


### PR DESCRIPTION
The README linked the preview image to https://youtu.be/dqK5DkgTGyk, which now returns 404. Keep the screenshot as a plain image and enable Lychee link checks in Ultralytics Actions (`links: true`), matching the rest of the organization.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Removed the broken YouTube link from the README preview image and enabled Lychee link checking in the formatting workflow to detect broken links.

### 📊 Key Changes

- Changed the README preview from a clickable image linking to YouTube into a plain `preview.jpg` image.
- Updated `.github/workflows/format.yml` to set `links: true` for Lychee broken-link checks.
- Preserved the existing README preview image while removing its dead video destination.

### 🎯 Purpose & Impact

- README visitors can no longer click the preview image to reach the unavailable YouTube video.
- The repository’s formatting workflow now checks links for future broken URLs.