### PR TITLE
Remove trailing slashes and update redirected Ultralytics URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -69,7 +69,7 @@ body:
     attributes:
       label: Minimal Reproducible Example
       description: >
-        When asking a question, people will be better able to provide help if you provide code that they can easily understand and use to **reproduce** the problem. This is referred to by community members as creating a [minimal reproducible example](https://docs.ultralytics.com/help/minimum-reproducible-example/).
+        When asking a question, people will be better able to provide help if you provide code that they can easily understand and use to **reproduce** the problem. This is referred to by community members as creating a [minimal reproducible example](https://docs.ultralytics.com/help/minimum-reproducible-example).
       placeholder: |
         ```matlab
         % Code to reproduce your issue here

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,7 +6,7 @@ contact_links:
     url: https://github.com/ultralytics/kinect#readme
     about: Repository overview and usage
   - name: 💬 Forum
-    url: https://community.ultralytics.com/
+    url: https://community.ultralytics.com
     about: Ask on Ultralytics Community Forum
   - name: 🎧 Discord
     url: https://ultralytics.com/discord

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-<a href="https://www.ultralytics.com/"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
+<a href="https://www.ultralytics.com"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
 
 # 🌟 Ultralytics Kinect
 
 [![Ultralytics Actions](https://github.com/ultralytics/kinect/actions/workflows/format.yml/badge.svg)](https://github.com/ultralytics/kinect/actions/workflows/format.yml)
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
-[![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)
+[![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com)
 [![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://reddit.com/r/ultralytics)
 
 Welcome to the [Ultralytics Kinect](https://github.com/ultralytics/kinect) repository! This project showcases advanced **3D scene reconstruction** algorithms utilizing data captured by the [Microsoft Kinect sensor](https://en.wikipedia.org/wiki/Kinect), a pioneering [depth-imaging](https://www.ultralytics.com/glossary/depth-estimation) device. Explore our implementation of cutting-edge techniques in [computer vision](https://www.ultralytics.com/glossary/computer-vision-cv) and see the results in action through example videos on the [Ultralytics YouTube channel](https://www.youtube.com/ultralytics).
@@ -33,7 +33,7 @@ Additionally, confirm that the following MATLAB toolboxes are installed:
 - [Computer Vision Toolbox](https://www.mathworks.com/products/computer-vision.html)
 - [Image Processing Toolbox](https://www.mathworks.com/products/image.html)
 
-For more details on setting up development environments, check out the general [Ultralytics documentation](https://docs.ultralytics.com/).
+For more details on setting up development environments, check out the general [Ultralytics documentation](https://docs.ultralytics.com).
 
 ## How to Run 🏃
 


### PR DESCRIPTION
Normalizes Ultralytics links in this repository to their canonical, non-redirecting form.

## Trailing slashes removed (5 across 3 files)

- `README.md` — logo link `https://www.ultralytics.com/`, Forums badge target `https://community.ultralytics.com/`, docs link `https://docs.ultralytics.com/`
- `.github/ISSUE_TEMPLATE/config.yml` — Forum contact link `https://community.ultralytics.com/`
- `.github/ISSUE_TEMPLATE/bug-report.yml` — `https://docs.ultralytics.com/help/minimum-reproducible-example/`

All five destinations were verified to return HTTP 200 with no redirect in their slash-free form. A repo-wide re-scan confirms zero remaining terminating slashes on `ultralytics.com` or any `*.ultralytics.com` URL. Path separators, the percent-encoded `server=https%3A%2F%2Fcommunity.ultralytics.com` badge parameter, and the `ultralytics.com/license` headers written by Ultralytics Actions were left byte-identical.

## Redirects reviewed, none baked in

Every URL in the repository was resolved serially; four redirect candidates were deliberately rejected:

- `https://ultralytics.com/discord` → `https://discord.com/invite/ultralytics` — vanity shortlink wrapping an expiring invite; the shortlink is the durable form.
- `https://ultralytics.com/license` → `https://www.ultralytics.com/license` — license-header string owned and rewritten by Ultralytics Actions; changing it would desync from the tool output.
- `https://reddit.com/r/ultralytics` → `https://www.reddit.com/r/ultralytics/` — host canonicalization rather than a content move, and the destination re-adds a trailing slash. Kept to match the shared social-badge block used across Ultralytics repositories.
- `.gitignore` template provenance comments pointing at `github.com/github/gitignore/blob/master/...` now resolve to `/blob/main/...` (GitHub default-branch rename). Left as provenance records for the copied templates; no functional impact.

## Dead link flagged for follow-up

`functions/MarchingCubes.m:21` cites `http://www.mhelm.de/octave/m/marching_cube.m` as the origin of the adapted Octave implementation. That host now redirects to `null-a.de`, which no longer resolves. It is an authorship attribution for third-party code, so it was left untouched — a human should decide whether to keep it as a historical citation or point it at an archived copy. This is pre-existing and unrelated to this diff.

## Validation

- Prettier 3.8.5 (`--print-width 120`) reports no formatting changes for `README.md` and all workflow/issue-template YAML.
- All six YAML files parse cleanly.
- No MATLAB sources are modified; the diff is URL text only.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated five Ultralytics URLs in the README and GitHub issue templates to use canonical forms without trailing slashes, avoiding redirects.

### 📊 Key Changes

- Removed trailing slashes from the Ultralytics homepage, Community Forum, documentation, and minimum reproducible example links.
- Updated the README logo, Forums badge, and documentation links.
- Updated the Forum contact link in `.github/ISSUE_TEMPLATE/config.yml` and the documentation link in `.github/ISSUE_TEMPLATE/bug-report.yml`.
- Left other reviewed URLs and provenance comments unchanged, including the Discord, license, Reddit, and third-party citation links.

### 🎯 Purpose & Impact

- Links now use their verified non-redirecting forms where changed, while the repository’s URL text and MATLAB sources remain otherwise unchanged.